### PR TITLE
add support for blacklist of version ids to ignore

### DIFF
--- a/analytics/package.json
+++ b/analytics/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@evolv-delivery/analytics",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Captures and processes evolv events with a set of configurable steps",
   "main": "dist/index.js",
   "scripts": {
     "build": "rollup --config rollup.config.js",
     "watch": "rollup --config rollup.config.js --watch",
-    "dev": "pushd dist; python -m SimpleHTTPServer 8000; popd",
+    "dev": "pushd dist; python3 -m http.server 8000; popd",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [

--- a/analytics/package.json
+++ b/analytics/package.json
@@ -1,8 +1,13 @@
 {
   "name": "@evolv-delivery/analytics",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Captures and processes evolv events with a set of configurable steps",
   "main": "dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "rollup --config rollup.config.js",
     "watch": "rollup --config rollup.config.js --watch",

--- a/analytics/rollup.config.js
+++ b/analytics/rollup.config.js
@@ -20,6 +20,15 @@ function buildFile(src){
         json()
       ]
     },
+    {
+      input: `./test/harness.js`,
+      output: {
+        file: `./dist/harness.js`,
+      },
+      plugins: [
+        json()
+      ]
+    },
   ]
 }
 

--- a/analytics/src/analytics.js
+++ b/analytics/src/analytics.js
@@ -43,6 +43,10 @@ function findMatchingConfig(configs){
 }
 
 function processStatements(pageConfig, eventType, evolvEvent){
+  if (pageConfig.blacklist && pageConfig.blacklist.includes(evolvEvent.group_id)){
+    return;
+  }
+
   function process(event){
     var statements = pageConfig.statements;
     var eventContext = new EventContext(event);

--- a/analytics/test/harness.js
+++ b/analytics/test/harness.js
@@ -1,0 +1,44 @@
+
+
+//nuf said
+////////////////////////////////////////////////
+import {processAnalytics} from '../src/analytics.js'
+import data from './data.json'
+
+function loadScript(path){
+  var scriptNode = document.createElement('script');
+  scriptNode.setAttribute('src', path);
+  document.head.appendChild(scriptNode);
+}
+
+
+function waitFor(check, invoke, poll){
+  if (check()){
+      invoke();
+      return;
+  }
+  var polling = setInterval(function(){
+    try{
+      if (check()){
+        invoke();
+        clearInterval(polling);
+        polling = null;
+      }
+    } catch(e){console.info('listener not processed')}
+  }, poll.interval)
+  setTimeout(function(){ 
+      if (!polling) return
+      
+      clearInterval(polling)     
+      console.info('evolv render listener timeout', poll)
+      window.evolvRenderTimeout = {
+          msg:'evolv render listener timeout', poll: poll
+      }
+  }, poll.duration)
+}
+
+waitFor(
+  () => window.evolv, 
+  ()=> processAnalytics(data),
+  {duration: 900000, interval:20}
+)


### PR DESCRIPTION
The analytics change is to allow version ids to be blacklisted for excluding flow specific experiments from sending analytics data (and potentially clobbering reporting data for adobe).

Also included a new harness for easier testing of integrations. This way we can simply run the `npm run dev` and reference the harness within resource override and it takes care of the insertions at the right point.