### PR TITLE
Fix whenItem method

### DIFF
--- a/catalyst/src/rule.js
+++ b/catalyst/src/rule.js
@@ -72,7 +72,7 @@ export function initializeRule($){
           var results = $('.evolv-'+(storeRef.asClass || name)).markOnce(attr);
           return results.length > 0 ? results : null;
         } catch (e){ 
-          console.warn('Evolv selector may be malformed for', exp, sel);
+          console.warn('Evolv selector may be malformed for', exp, name);
         }
       })
     }


### PR DESCRIPTION
This fixes the `sel not defined` error that's been spamming with the newest version of Catalyst