### PR TITLE
Utils: Upgrade namespace

### DIFF
--- a/utils/docs/API.md
+++ b/utils/docs/API.md
@@ -86,7 +86,6 @@ Appends an encoded (optionally) value to the specifiec cookie.
 document.cookie = 'throttle=|EnableTest1';
 utils.cookie.appendItem('|EnableTest2');
 document.cookie; // 'throttle=%7CEnableTest1%7CEnableTest2'
-;
 ```
 <a name="Utils"></a>
 
@@ -95,6 +94,7 @@ document.cookie; // 'throttle=%7CEnableTest1%7CEnableTest2'
 
 * [Utils](#Utils)
     * [new Utils(id, config)](#new_Utils_new)
+    * [.toRevert](#Utils+toRevert)
     * [.log](#Utils+log)
     * [.debug](#Utils+debug)
     * [.warn](#Utils+warn)
@@ -111,7 +111,7 @@ document.cookie; // 'throttle=%7CEnableTest1%7CEnableTest2'
     * [.slugify(string)](#Utils+slugify) ⇒ <code>string</code>
     * [.makeElements(HTMLString, clickHandlers)](#Utils+makeElements) ⇒ <code>Array.&lt;HTMLElement&gt;</code>
     * [.makeElement(HTMLString, clickHandlers)](#Utils+makeElement) ⇒ <code>HTMLElement</code>
-    * [.$(selector)](#Utils+$) ⇒ <code>Array.&lt;HTMLElement&gt;</code>
+    * [.$(selector)](#Utils+$) ⇒ <code>HTMLElement</code>
     * [.$$(selector)](#Utils+$$) ⇒ <code>Array.&lt;HTMLElement&gt;</code>
 
 <a name="new_Utils_new"></a>
@@ -125,6 +125,21 @@ The utils object containing all helper functions
 | id | <code>string</code> | A unique key for referencing the utils sandbox |
 | config | <code>Object</code> | A configuration object that defines the project. Used by <code>describe()</code> |
 
+<a name="Utils+toRevert"></a>
+
+### utils.toRevert
+An array of callbacks to be executed on context exit. Used by [.namespace](#Utils+namespace)
+and can also be used for custom tear-down/clean-up functions if you have problems with
+elements persisting after SPA navigation changes. This does require the Evolv Client to
+have the current active keys transition to inactive to trigger, so in the Web Editor it
+won't fire in Edit mode. It also requires the `config` object to contain the context key
+as it matches in the YML. If your `config.contexts[0].id` is not the same you can add the
+following to the top level of `config`:
+```js
+ context_key: this.key,
+```
+
+**Kind**: instance property of [<code>Utils</code>](#Utils)  
 <a name="Utils+log"></a>
 
 ### utils.log
@@ -270,7 +285,10 @@ Wraps an element or a group of elements with an HTML element defined by a string
 <a name="Utils+namespace"></a>
 
 ### utils.namespace
-Adds classes prefixed with `evolv-` to the body element.
+Adds classes prefixed with `evolv-` to the body element. Comma delimited arguments
+are separated by dashes. By default `namespace()` will observe classes on the body
+element and replace the class if it is removed. Automatically reverts classes on
+context exit if the context key is supplied in the `config` object. See [.toRevert](#Utils+toRevert)
 
 **Kind**: instance property of [<code>Utils</code>](#Utils)  
 
@@ -278,6 +296,13 @@ Adds classes prefixed with `evolv-` to the body element.
 | --- | --- | --- |
 | ...args | <code>string</code> \| <code>number</code> | The namespace |
 
+**Example**  
+```js
+namespace('new-experiment', 'c1');
+namespace('new-experiment', 'c1', 'v2');
+
+document.querySelector('body') // body.evolv-new-experiment-c1.evolv-new-experiment-c1-v2
+```
 <a name="Utils+throttle"></a>
 
 ### utils.throttle(callback, limit) ⇒ <code>function</code>
@@ -346,11 +371,11 @@ Creates an element from an HTML string and adds click handlers to the element.
 
 <a name="Utils+$"></a>
 
-### utils.$(selector) ⇒ <code>Array.&lt;HTMLElement&gt;</code>
+### utils.$(selector) ⇒ <code>HTMLElement</code>
 Selects an element from the DOM or creates new element from an HTML string.
 
 **Kind**: instance method of [<code>Utils</code>](#Utils)  
-**Returns**: <code>Array.&lt;HTMLElement&gt;</code> - An array containing a single element  
+**Returns**: <code>HTMLElement</code> - A single element  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -362,7 +387,7 @@ Selects an element from the DOM or creates new element from an HTML string.
 Selects elements from the DOM or creates new elements from an HTML string.
 
 **Kind**: instance method of [<code>Utils</code>](#Utils)  
-**Returns**: <code>Array.&lt;HTMLElement&gt;</code> - The array of elements  
+**Returns**: <code>Array.&lt;HTMLElement&gt;</code> - An array of result elements  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evolv-delivery/utils",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A library of helper functions for writing experiments",
   "main": "dist/index.js",
   "type": "module",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evolv-delivery/utils",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A library of helper functions for writing experiments",
   "main": "dist/index.js",
   "type": "module",

--- a/utils/src/index.js
+++ b/utils/src/index.js
@@ -7,7 +7,7 @@ import Utils from './utils.js';
  * @returns {Utils} A reference to the newly created Utils instance
  */
 function init(id, config) {
-  const utilsOld = window.evolv.utils?.[id];
+  const utilsOld = id ? window.evolv.utils?.[id] : window.evolv.utils;
   if (utilsOld) {
     return utilsOld;
   }

--- a/utils/src/namespace.js
+++ b/utils/src/namespace.js
@@ -1,0 +1,46 @@
+/**
+ *
+ * @param {Utils} utils The current Utils object.
+ */
+export default function initNamespace(utils) {
+  const { body } = document;
+  const { addClass, removeClass, toRevert } = utils;
+
+  const namespaceClasses = new Set();
+  let bodyClassObserver;
+  let bodyClassObserving = false;
+
+  function updateBodyClasses() {
+    if (!bodyClassObserving) {
+      return;
+    }
+    namespaceClasses.forEach((className) => addClass(body, className));
+  }
+
+  function revertBodyClasses() {
+    bodyClassObserving = false;
+    bodyClassObserver.disconnect();
+    namespaceClasses.forEach((className) => removeClass(body, className));
+  }
+
+  function initBodyClassObserver() {
+    bodyClassObserver = new MutationObserver(updateBodyClasses);
+    bodyClassObserver.observe(body, {
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+    bodyClassObserving = true;
+    toRevert.push(revertBodyClasses);
+  }
+
+  function namespace(...args) {
+    const className = ['evolv', ...args].join('-');
+    addClass(body, className);
+    namespaceClasses.add(className);
+    if (!bodyClassObserver && !bodyClassObserving) {
+      initBodyClassObserver();
+    }
+  }
+
+  return namespace;
+}

--- a/utils/src/utils.js
+++ b/utils/src/utils.js
@@ -70,12 +70,12 @@ class Utils {
           return;
         }
 
-        this.log(`active keys: init key watching for '${this.contextKey}'`);
+        this.log(`key watcher: init key watching for '${this.contextKey}'`);
 
         window.evolv.client.getActiveKeys(this.contextKey).listen((keys) => {
           // Determine if user is exiting the context
           if (keys.previous.length && !keys.current.length) {
-            this.log(`active keys: exit context '${this.contextKey}'`);
+            this.log(`key watcher: exit context '${this.contextKey}'`);
             let index = this.toRevert.length;
             while (index--) {
               this.toRevert[index]();
@@ -368,7 +368,7 @@ class Utils {
    */
   addClass = (element, className) => {
     if (!element.classList.contains(className)) {
-      this.debug(`add-class: '${className}' added`);
+      this.debug(`add class: '${className}' added`);
       element.classList.add(className);
     }
   };
@@ -380,7 +380,7 @@ class Utils {
    */
   removeClass = (element, className) => {
     if (element.classList.contains(className)) {
-      this.debug(`remove-class: '${className}' removed`);
+      this.debug(`remove class: '${className}' removed`);
       element.classList.remove(className);
     }
   };
@@ -392,7 +392,7 @@ class Utils {
    */
   updateText = (element, text) => {
     if (element.innerText !== text) {
-      this.debug(`update-text: text replaced with '${text}'`);
+      this.debug(`update text: text replaced with '${text}'`);
       /* eslint-disable-next-line no-param-reassign */
       element.innerText = text;
     }

--- a/utils/src/utils.js
+++ b/utils/src/utils.js
@@ -1,6 +1,8 @@
 /* eslint-disable class-methods-use-this */
+/* eslint-disable no-plusplus */
 import { version } from '../package.json';
 import CookieMethods from './cookies.js';
+import initNamespace from './namespace.js';
 
 /***
  * Creates the prefix for a log message.
@@ -25,6 +27,20 @@ class Utils {
   #logPrefixDebug;
 
   /**
+   * An array of callbacks to be executed on context exit. Used by [.namespace](#Utils+namespace)
+   * and can also be used for custom tear-down/clean-up functions if you have problems with
+   * elements persisting after SPA navigation changes. This does require the Evolv Client to
+   * have the current active keys transition to inactive to trigger, so in the Web Editor it
+   * won't fire in Edit mode. It also requires the `config` object to contain the context key
+   * as it matches in the YML. If your `config.contexts[0].id` is not the same you can add the
+   * following to the top level of `config`:
+   * ```js
+   *  context_key: this.key,
+   * ```
+   */
+  toRevert = [];
+
+  /**
    * The utils object containing all helper functions
    * @param {string} id A unique key for referencing the utils sandbox
    * @param {Object} config A configuration object that defines the project. Used by <code>describe()</code>
@@ -42,6 +58,32 @@ class Utils {
     this.#logPrefixDebug = getlogPrefix(id, 0.5);
 
     this.version = version;
+    this.contextKey = config?.context_key || config?.contexts?.[0]?.id || null;
+
+    if (this.contextKey) {
+      if (!this.contextKey.startsWith('web.')) {
+        this.contextKey = `web.${this.contextKey}`;
+      }
+
+      window.evolv.client.getActiveKeys(this.contextKey).then(({ current }) => {
+        if (!current.length) {
+          return;
+        }
+
+        this.log(`active keys: init key watching for '${this.contextKey}'`);
+
+        window.evolv.client.getActiveKeys(this.contextKey).listen((keys) => {
+          // Determine if user is exiting the context
+          if (keys.previous.length && !keys.current.length) {
+            this.log(`active keys: exit context '${this.contextKey}'`);
+            let index = this.toRevert.length;
+            while (index--) {
+              this.toRevert[index]();
+            }
+          }
+        });
+      });
+    }
   }
 
   /**
@@ -279,26 +321,18 @@ class Utils {
   /**
    * Selects an element from the DOM or creates new element from an HTML string.
    * @param {string} selector The CSS selector, XPath expression, or HTML string
-   * @returns {HTMLElement[]} An array containing a single element
+   * @returns {HTMLElement} A single element
    */
   $(selector) {
     switch (selector.charAt(0)) {
       case '/':
       case '(': {
-        const result = document.evaluate(
-          selector,
-          document,
-          null,
-          XPathResult.FIRST_ORDERED_NODE_TYPE,
-          null,
-        ).singleNodeValue;
-        return result ? [result] : [];
+        return document.evaluate(selector, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
       }
       case '<':
-        return [this.makeElement(selector)];
+        return this.makeElement(selector);
       default: {
-        const result = document.querySelector(selector);
-        return result ? [result] : [];
+        return document.querySelector(selector);
       }
     }
   }
@@ -306,7 +340,7 @@ class Utils {
   /**
    * Selects elements from the DOM or creates new elements from an HTML string.
    * @param {string} selector The CSS selector, XPath expression, or HTML string
-   * @returns {HTMLElement[]} The array of elements
+   * @returns {HTMLElement[]} An array of result elements
    */
   $$(selector) {
     switch (selector.charAt(0)) {
@@ -380,12 +414,18 @@ class Utils {
   };
 
   /**
-   * Adds classes prefixed with `evolv-` to the body element.
+   * Adds classes prefixed with `evolv-` to the body element. Comma delimited arguments
+   * are separated by dashes. By default `namespace()` will observe classes on the body
+   * element and replace the class if it is removed. Automatically reverts classes on
+   * context exit if the context key is supplied in the `config` object. See [.toRevert](#Utils+toRevert)
    * @param {...(string|number)} args The namespace
+   * @example
+   * namespace('new-experiment', 'c1');
+   * namespace('new-experiment', 'c1', 'v2');
+   *
+   * document.querySelector('body') // body.evolv-new-experiment-c1.evolv-new-experiment-c1-v2
    */
-  namespace = (...args) => {
-    this.addClass(document.body, ['evolv', ...args].join('-'));
-  };
+  namespace = initNamespace(this);
 }
 
 export default Utils;

--- a/utils/src/utils.js
+++ b/utils/src/utils.js
@@ -29,11 +29,11 @@ class Utils {
   /**
    * An array of callbacks to be executed on context exit. Used by [.namespace](#Utils+namespace)
    * and can also be used for custom tear-down/clean-up functions if you have problems with
-   * elements persisting after SPA navigation changes. This does require the Evolv Client to
-   * have the current active keys transition to inactive to trigger, so in the Web Editor it
-   * won't fire in Edit mode. It also requires the `config` object to contain the context key
-   * as it matches in the YML. If your `config.contexts[0].id` is not the same you can add the
-   * following to the top level of `config`:
+   * elements persisting after SPA navigation changes. Reversion triggers when the current active
+   * key transitions to inactive, so in the Web Editor it won't fire in Edit mode. It also requires
+   * the `config` object to contain the context key as it matches in the YML. If `config.contexts[0].id`
+   * is not the same as the context key in the YML you can add the following to the top level of
+   * `config`:
    * ```js
    *  context_key: this.key,
    * ```


### PR DESCRIPTION
1. Adds persistence and reversion to `.namespace`
2. `$` now returns an element instead of an array containing a single element. This was a legacy inconvenience for compatibility with the utils observer which we no longer use. I checked, there are no current experiments using `$`